### PR TITLE
fix(app): Fix layout selector cutoff in Start Session dialog

### DIFF
--- a/PromptConduit/Features/Agent/SessionLauncherView.swift
+++ b/PromptConduit/Features/Agent/SessionLauncherView.swift
@@ -506,9 +506,6 @@ struct SessionLauncherView: View {
                     }
                 }
                 .pickerStyle(.segmented)
-                .frame(maxWidth: 280)
-
-                Spacer()
             }
 
             // Multi-launch button


### PR DESCRIPTION
## Summary
- Fixed the layout selector being cut off when multiple repos are selected in the Start Session dialog
- The "Auto" label was partially hidden due to a restrictive width constraint

## Changes
Removed the `.frame(maxWidth: 280)` constraint on the segmented picker in `SessionLauncherView.swift`. This allows the picker to expand naturally and display all 6 layout options (Auto, Horizontal, Vertical, 2×2 Grid, 2×3 Grid, 2×4 Grid) without truncation.

## Test plan
- [ ] Launch the app
- [ ] Open "Start Session" dialog
- [ ] Enable Multi-select mode and select 2+ repos
- [ ] Verify all layout options are fully visible and not cut off

🤖 Generated with [Claude Code](https://claude.com/claude-code)