### PR TITLE
feat(app): Add CLI hook-based session status detection

### DIFF
--- a/PromptConduit/Services/HookNotificationService.swift
+++ b/PromptConduit/Services/HookNotificationService.swift
@@ -33,10 +33,12 @@ class HookNotificationService: ObservableObject {
     /// Published events
     @Published private(set) var lastSessionStartEvent: SessionStartEvent?
     @Published private(set) var lastStopEvent: StopEvent?
+    @Published private(set) var lastUserPromptSubmitEvent: UserPromptSubmitEvent?
 
     // Callbacks
     var onSessionStart: ((SessionStartEvent) -> Void)?
     var onStop: ((StopEvent) -> Void)?
+    var onUserPromptSubmit: ((UserPromptSubmitEvent) -> Void)?
 
     private init() {}
 
@@ -128,8 +130,6 @@ class HookNotificationService: ObservableObject {
                         timestamp: Date()
                     )
                     lastSessionStartEvent = event
-                    debugLog("SessionStart event: \(event.cwd)")
-                    debugLog("onSessionStart callback: \(onSessionStart != nil ? "set" : "nil")")
                     onSessionStart?(event)
 
                 case "Stop":
@@ -139,8 +139,16 @@ class HookNotificationService: ObservableObject {
                         timestamp: Date()
                     )
                     lastStopEvent = event
-                    debugLog("Stop event: \(event.cwd)")
                     onStop?(event)
+
+                case "UserPromptSubmit":
+                    let event = UserPromptSubmitEvent(
+                        cwd: dict["cwd"] as? String ?? "",
+                        sessionId: dict["session_id"] as? String,
+                        timestamp: Date()
+                    )
+                    lastUserPromptSubmitEvent = event
+                    onUserPromptSubmit?(event)
 
                 default:
                     debugLog("Unknown event type: \(eventType)")
@@ -161,6 +169,12 @@ struct SessionStartEvent {
 }
 
 struct StopEvent {
+    let cwd: String
+    let sessionId: String?
+    let timestamp: Date
+}
+
+struct UserPromptSubmitEvent {
     let cwd: String
     let sessionId: String?
     let timestamp: Date


### PR DESCRIPTION
## Summary
Replace fragile terminal output parsing with reliable CLI hook events for detecting session waiting/running state in multi-terminal views.

## Changes
- **HookNotificationService.swift**: Add `UserPromptSubmitEvent` parsing and `onUserPromptSubmit` callback
- **TerminalSessionManager.swift**: 
  - Add `setupHookListening()` to subscribe to hook events
  - Add `updateSessionStateFromCwd()` to match events to sessions by working directory
  - Default new sessions to `isWaiting: true`

## How It Works
State transitions from CLI hook events:
- `SessionStart` → **Waiting** (Claude ready for input)
- `UserPromptSubmit` → **Running** (user sent prompt)  
- `Stop` → **Waiting** (Claude finished responding)

## Testing
- Tested with multi-session (2 repos)
- Sessions correctly show "Waiting" when Claude displays suggestion prompt
- Sessions correctly show "Running" when Claude is actively processing
- Status updates reliably via hook events instead of output pattern matching

## Dependencies
Requires companion CLI PR to write events to `~/.promptconduit/hook-events`

🤖 Generated with [Claude Code](https://claude.com/claude-code)