### PR TITLE
feat(app): Pass initial prompt from launcher to terminal session

### DIFF
--- a/PromptConduit/Features/Agent/AgentPanelController.swift
+++ b/PromptConduit/Features/Agent/AgentPanelController.swift
@@ -110,11 +110,11 @@ class AgentPanelController {
                 // Resume the session
                 self?.resumeAgent(from: sessionHistory)
             },
-            onLaunchTerminal: { [weak self, weak panel] directory in
+            onLaunchTerminal: { [weak self, weak panel] directory, initialPrompt in
                 // Close the launcher
                 panel?.close()
                 // Launch embedded terminal
-                self?.launchTerminal(in: directory)
+                self?.launchTerminal(in: directory, initialPrompt: initialPrompt)
             },
             onLaunchMultiTerminal: { [weak self, weak panel] repositories, layout, initialPrompt in
                 // Close the launcher
@@ -347,7 +347,7 @@ class AgentPanelController {
     }
 
     /// Launches an embedded terminal with Claude Code
-    private func launchTerminal(in directory: String) {
+    private func launchTerminal(in directory: String, initialPrompt: String? = nil) {
         let panel = createTerminalPanel()
         let repoName = URL(fileURLWithPath: directory).lastPathComponent
         panel.title = "Claude Code - \(repoName)"
@@ -364,8 +364,10 @@ class AgentPanelController {
 
         // Create terminal session view with callbacks
         let view = TerminalSessionView(
+            sessionId: terminalId,
             repoName: repoName,
             workingDirectory: directory,
+            initialPrompt: initialPrompt,
             onClose: { [weak panel] in
                 // Terminate session and clean up
                 TerminalSessionManager.shared.terminateSession(terminalId)

--- a/PromptConduit/Features/Agent/SessionLauncherView.swift
+++ b/PromptConduit/Features/Agent/SessionLauncherView.swift
@@ -24,7 +24,7 @@ private enum LauncherTokens {
 struct SessionLauncherView: View {
     let onStartNew: (String, String) -> Void
     let onResume: (SessionHistory) -> Void
-    let onLaunchTerminal: (String) -> Void  // Launch single embedded terminal with directory
+    let onLaunchTerminal: (String, String?) -> Void  // Launch single embedded terminal with directory and optional prompt
     let onLaunchMultiTerminal: ([String], GridLayout, String?) -> Void  // Launch multiple terminals
     let onCancel: () -> Void
 
@@ -467,7 +467,7 @@ struct SessionLauncherView: View {
     private var singleLaunchButton: some View {
         Button(action: {
             settings.addRecentRepository(path: effectiveDirectory)
-            onLaunchTerminal(effectiveDirectory)
+            onLaunchTerminal(effectiveDirectory, prompt.isEmpty ? nil : prompt)
         }) {
             HStack(spacing: 8) {
                 Image(systemName: "terminal.fill")


### PR DESCRIPTION
## Summary
- Enables the terminal session to receive an initial prompt from the launcher and automatically send it to Claude Code once the terminal is ready
- Adds "Waiting" status indicator that reflects session state from TerminalSessionManager

## Changes
- **SessionLauncherView**: Pass optional prompt along with directory in `onLaunchTerminal` callback
- **AgentPanelController**: Thread `initialPrompt` parameter through to `TerminalSessionView`
- **EmbeddedTerminalView**: Add `sessionId` and `initialPrompt` parameters to `TerminalSessionView`
- **TerminalSessionView**: Auto-send prompt when `onClaudeReady` fires, show Waiting state in status indicator

## Testing
- Built successfully with `xcodebuild`
- Ran existing test suite (pre-existing test failures in `PTYSessionTests` unrelated to these changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)