### PR TITLE
feat(app): Add pattern detection for repeated prompts

### DIFF
--- a/macOS/PromptConduit.xcodeproj/project.pbxproj
+++ b/macOS/PromptConduit.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		04B1C2D3E4F5A67890BC2346 /* TranscriptIndexService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04B1C2D3E4F5A67890BC2347 /* TranscriptIndexService.swift */; };
 		04B1C2D3E4F5A67890BC2348 /* TranscriptParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04B1C2D3E4F5A67890BC2349 /* TranscriptParserTests.swift */; };
 		04B1C2D3E4F5A67890BC234A /* EmbeddingServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04B1C2D3E4F5A67890BC234B /* EmbeddingServiceTests.swift */; };
+		04C1D2E3F4A5B67890CD2350 /* PatternDetectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C1D2E3F4A5B67890CD2351 /* PatternDetectionService.swift */; };
+		04C1D2E3F4A5B67890CD2352 /* PatternDetectionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C1D2E3F4A5B67890CD2353 /* PatternDetectionServiceTests.swift */; };
 		04ED0B71263511058262BE8A /* TerminalOutputMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D0C878325B21553F2FA55A /* TerminalOutputMonitor.swift */; };
 		05A3AECF2D14572CFFD37CE1 /* PTYSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E0E605902CC4527F31B7CC2 /* PTYSession.swift */; };
 		09E21C20031C6E2DDE1BEFCC /* TerminalSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 199C59B522537F6E55F7C7FC /* TerminalSessionManager.swift */; };
@@ -73,6 +75,8 @@
 		04B1C2D3E4F5A67890BC2347 /* TranscriptIndexService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptIndexService.swift; sourceTree = "<group>"; };
 		04B1C2D3E4F5A67890BC2349 /* TranscriptParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptParserTests.swift; sourceTree = "<group>"; };
 		04B1C2D3E4F5A67890BC234B /* EmbeddingServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddingServiceTests.swift; sourceTree = "<group>"; };
+		04C1D2E3F4A5B67890CD2351 /* PatternDetectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatternDetectionService.swift; sourceTree = "<group>"; };
+		04C1D2E3F4A5B67890CD2353 /* PatternDetectionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatternDetectionServiceTests.swift; sourceTree = "<group>"; };
 		05CF87CE2D41BCD266905EE2 /* PromptConduit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PromptConduit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0D34EAE5DAAEEF85C90498E8 /* PromptConduitApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptConduitApp.swift; sourceTree = "<group>"; };
 		0E0E605902CC4527F31B7CC2 /* PTYSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PTYSession.swift; sourceTree = "<group>"; };
@@ -182,6 +186,7 @@
 				21C66B19CC6B7A578E29246A /* HookNotificationService.swift */,
 				5326D3178EE1608E20C3E6CB /* ImageAttachmentService.swift */,
 				EACBD1049D1F118A4A59672F /* NotificationService.swift */,
+				04C1D2E3F4A5B67890CD2351 /* PatternDetectionService.swift */,
 				28E249FE84141C631CAA2DF2 /* ProcessDetectionService.swift */,
 				8AFDA1DAFE542BFD87056608 /* SettingsService.swift */,
 				AF8BDAA52F7C52621E8DA50B /* SlashCommandsService.swift */,
@@ -218,6 +223,7 @@
 				04A1B2C3D4E5F67890AB1239 /* ClaudeSessionDiscoveryTests.swift */,
 				04B1C2D3E4F5A67890BC234B /* EmbeddingServiceTests.swift */,
 				0466CEEC8F3A4711F399B387 /* OutputParserTests.swift */,
+				04C1D2E3F4A5B67890CD2353 /* PatternDetectionServiceTests.swift */,
 				8EE5B376EB05B0E9B6E7AE42 /* PTYSessionTests.swift */,
 				7B2E2F8E424E5429A197D7E2 /* TerminalOutputMonitorTests.swift */,
 				04B1C2D3E4F5A67890BC2349 /* TranscriptParserTests.swift */,
@@ -399,6 +405,7 @@
 				22B846A8C1C72A58560F1ACC /* MultiTerminalGridView.swift in Sources */,
 				303D5CB5163D9DEAB1338DEA /* NotificationService.swift in Sources */,
 				F1AD359EBC54ED462C348466 /* OutputParser.swift in Sources */,
+				04C1D2E3F4A5B67890CD2350 /* PatternDetectionService.swift in Sources */,
 				05A3AECF2D14572CFFD37CE1 /* PTYSession.swift in Sources */,
 				A2742FBCF423780F362835BD /* ProcessDetectionService.swift in Sources */,
 				916E014FC116CDF3596EA407 /* PromptConduitApp.swift in Sources */,
@@ -428,6 +435,7 @@
 				04A1B2C3D4E5F67890AB123A /* ClaudeSessionDiscoveryTests.swift in Sources */,
 				04B1C2D3E4F5A67890BC234A /* EmbeddingServiceTests.swift in Sources */,
 				AFD03EFA8FFF1D5F86A5B2D4 /* OutputParserTests.swift in Sources */,
+				04C1D2E3F4A5B67890CD2352 /* PatternDetectionServiceTests.swift in Sources */,
 				BEA9671906B7E73606AF25A9 /* PTYSessionTests.swift in Sources */,
 				FC7674AC55E02D109EF50068 /* TerminalOutputMonitorTests.swift in Sources */,
 				04B1C2D3E4F5A67890BC2348 /* TranscriptParserTests.swift in Sources */,

--- a/macOS/PromptConduit/Services/PatternDetectionService.swift
+++ b/macOS/PromptConduit/Services/PatternDetectionService.swift
@@ -1,0 +1,360 @@
+import Foundation
+import Combine
+
+// MARK: - Data Types
+
+/// A member of a detected pattern cluster
+struct PatternMember: Identifiable {
+    let id: Int64
+    let message: IndexedMessage
+    let similarityToRepresentative: Double
+}
+
+/// Scoring metrics for pattern ranking
+struct PatternScore {
+    let count: Int
+    let sessionDiversity: Int
+    let repoDiversity: Int
+    let avgSimilarity: Double
+    let mostRecent: Date
+
+    var compositeScore: Double {
+        // Logarithmic scaling for count (diminishing returns)
+        let countScore = log(Double(count) + 1) * 2.0
+
+        // Bonus for appearing across multiple sessions
+        let diversityBonus = Double(sessionDiversity) * 0.5
+
+        // Coherence bonus for tight clusters
+        let coherenceBonus = avgSimilarity * 2.0
+
+        // Recency bonus (decay over 30 days)
+        let daysSinceMostRecent = Date().timeIntervalSince(mostRecent) / 86400
+        let recencyBonus = max(0, 1.0 - (daysSinceMostRecent / 30.0))
+
+        return countScore + diversityBonus + coherenceBonus + recencyBonus
+    }
+}
+
+/// A detected pattern of similar user prompts
+struct DetectedPattern: Identifiable {
+    let id: UUID
+    let representative: IndexedMessage
+    let members: [PatternMember]
+    let score: PatternScore
+
+    var count: Int { members.count }
+    var sessionCount: Int { Set(members.map { $0.message.sessionId }).count }
+    var repoCount: Int { Set(members.map { $0.message.repoPath }).count }
+
+    /// Preview of the pattern (first N characters of representative content)
+    var preview: String {
+        let content = representative.content
+        if content.count <= 100 {
+            return content
+        }
+        return String(content.prefix(100)) + "..."
+    }
+}
+
+// MARK: - Union-Find for Clustering
+
+/// Union-Find data structure for efficient clustering
+private class UnionFind {
+    private var parent: [Int]
+    private var rank: [Int]
+
+    init(count: Int) {
+        parent = Array(0..<count)
+        rank = Array(repeating: 0, count: count)
+    }
+
+    func find(_ x: Int) -> Int {
+        if parent[x] != x {
+            parent[x] = find(parent[x])  // Path compression
+        }
+        return parent[x]
+    }
+
+    func union(_ x: Int, _ y: Int) {
+        let rootX = find(x)
+        let rootY = find(y)
+
+        if rootX == rootY { return }
+
+        // Union by rank
+        if rank[rootX] < rank[rootY] {
+            parent[rootX] = rootY
+        } else if rank[rootX] > rank[rootY] {
+            parent[rootY] = rootX
+        } else {
+            parent[rootY] = rootX
+            rank[rootX] += 1
+        }
+    }
+
+    func getComponents() -> [[Int]] {
+        var components: [Int: [Int]] = [:]
+        for i in 0..<parent.count {
+            let root = find(i)
+            components[root, default: []].append(i)
+        }
+        return Array(components.values)
+    }
+}
+
+// MARK: - Pattern Detection Service
+
+/// Service for detecting patterns in user prompts across sessions
+class PatternDetectionService: ObservableObject {
+
+    static let shared = PatternDetectionService()
+
+    // MARK: - Published State
+
+    @Published private(set) var isAnalyzing = false
+    @Published private(set) var patterns: [DetectedPattern] = []
+    @Published private(set) var lastAnalyzed: Date?
+    @Published private(set) var lastError: String?
+
+    // MARK: - Private Properties
+
+    private var database: TranscriptIndexDatabase?
+    private let embedder = EmbeddingService()
+    private let analysisQueue = DispatchQueue(label: "com.promptconduit.patterndetection", qos: .utility)
+
+    // MARK: - Initialization
+
+    private init() {
+        do {
+            database = try TranscriptIndexDatabase()
+        } catch {
+            lastError = "Failed to initialize database: \(error.localizedDescription)"
+        }
+    }
+
+    // MARK: - Public API
+
+    /// Detect patterns in user prompts
+    /// - Parameters:
+    ///   - minSimilarity: Minimum similarity threshold for grouping (default: 0.75)
+    ///   - minClusterSize: Minimum messages to form a pattern (default: 2)
+    ///   - maxPatterns: Maximum patterns to return (default: 50)
+    func detectPatterns(
+        minSimilarity: Double = 0.75,
+        minClusterSize: Int = 2,
+        maxPatterns: Int = 50
+    ) {
+        guard !isAnalyzing else { return }
+        guard let database = database else {
+            lastError = "Database not available"
+            return
+        }
+
+        isAnalyzing = true
+        lastError = nil
+
+        analysisQueue.async { [weak self] in
+            guard let self = self else { return }
+
+            let detectedPatterns = self.performPatternDetection(
+                database: database,
+                minSimilarity: minSimilarity,
+                minClusterSize: minClusterSize,
+                maxPatterns: maxPatterns
+            )
+
+            DispatchQueue.main.async {
+                self.patterns = detectedPatterns
+                self.lastAnalyzed = Date()
+                self.isAnalyzing = false
+            }
+        }
+    }
+
+    /// Get patterns filtered by repository
+    func patternsForRepo(_ repoPath: String) -> [DetectedPattern] {
+        return patterns.filter { pattern in
+            pattern.members.contains { $0.message.repoPath == repoPath }
+        }
+    }
+
+    /// Clear detected patterns
+    func clearPatterns() {
+        patterns = []
+        lastAnalyzed = nil
+    }
+
+    // MARK: - Pattern Detection Algorithm
+
+    private func performPatternDetection(
+        database: TranscriptIndexDatabase,
+        minSimilarity: Double,
+        minClusterSize: Int,
+        maxPatterns: Int
+    ) -> [DetectedPattern] {
+
+        // Step 1: Get all user message embeddings
+        let userMessages = database.getUserMessageEmbeddings()
+        guard userMessages.count >= minClusterSize else {
+            return []
+        }
+
+        // Step 2: Build similarity graph and cluster using Union-Find
+        let clusters = clusterMessages(
+            messages: userMessages,
+            minSimilarity: minSimilarity
+        )
+
+        // Step 3: Filter to minimum cluster size
+        let validClusters = clusters.filter { $0.count >= minClusterSize }
+
+        // Step 4: Fetch full message data for clusters
+        let allIds = validClusters.flatMap { $0.map { userMessages[$0].id } }
+        let messagesById = Dictionary(
+            uniqueKeysWithValues: database.getMessagesByIds(allIds).map { ($0.id, $0) }
+        )
+
+        // Step 5: Build patterns with scoring
+        var detectedPatterns: [DetectedPattern] = []
+
+        for cluster in validClusters {
+            let clusterMessages = cluster.compactMap { idx -> (idx: Int, message: IndexedMessage)? in
+                let id = userMessages[idx].id
+                guard let message = messagesById[id] else { return nil }
+                return (idx: idx, message: message)
+            }
+
+            guard clusterMessages.count >= minClusterSize else { continue }
+
+            // Find representative (most central message)
+            let representative = findRepresentative(
+                clusterMessages: clusterMessages,
+                allMessages: userMessages
+            )
+
+            // Build pattern members with similarity to representative
+            let members = clusterMessages.map { item -> PatternMember in
+                let similarity = embedder.cosineSimilarity(
+                    userMessages[item.idx].embedding,
+                    userMessages[representative.idx].embedding
+                )
+                return PatternMember(
+                    id: item.message.id,
+                    message: item.message,
+                    similarityToRepresentative: similarity
+                )
+            }.sorted { $0.similarityToRepresentative > $1.similarityToRepresentative }
+
+            // Calculate pattern score
+            let score = calculatePatternScore(members: members, allMessages: userMessages, clusterIndices: cluster)
+
+            let pattern = DetectedPattern(
+                id: UUID(),
+                representative: representative.message,
+                members: members,
+                score: score
+            )
+
+            detectedPatterns.append(pattern)
+        }
+
+        // Step 6: Sort by composite score and limit
+        detectedPatterns.sort { $0.score.compositeScore > $1.score.compositeScore }
+        return Array(detectedPatterns.prefix(maxPatterns))
+    }
+
+    /// Cluster messages using Union-Find based on similarity threshold
+    private func clusterMessages(
+        messages: [(id: Int64, sessionId: String, repoPath: String, timestamp: Date, embedding: [Double])],
+        minSimilarity: Double
+    ) -> [[Int]] {
+        let n = messages.count
+        let uf = UnionFind(count: n)
+
+        // O(n²) pairwise comparison - acceptable for <10K messages
+        for i in 0..<n {
+            for j in (i + 1)..<n {
+                let similarity = embedder.cosineSimilarity(
+                    messages[i].embedding,
+                    messages[j].embedding
+                )
+                if similarity >= minSimilarity {
+                    uf.union(i, j)
+                }
+            }
+        }
+
+        return uf.getComponents()
+    }
+
+    /// Find the most representative (central) message in a cluster
+    private func findRepresentative(
+        clusterMessages: [(idx: Int, message: IndexedMessage)],
+        allMessages: [(id: Int64, sessionId: String, repoPath: String, timestamp: Date, embedding: [Double])]
+    ) -> (idx: Int, message: IndexedMessage) {
+        guard clusterMessages.count > 1 else {
+            return clusterMessages[0]
+        }
+
+        // Find message with highest average similarity to all others
+        var bestIdx = clusterMessages[0].idx
+        var bestMessage = clusterMessages[0].message
+        var bestAvgSimilarity = -1.0
+
+        for item in clusterMessages {
+            var totalSimilarity = 0.0
+            for other in clusterMessages where other.idx != item.idx {
+                totalSimilarity += embedder.cosineSimilarity(
+                    allMessages[item.idx].embedding,
+                    allMessages[other.idx].embedding
+                )
+            }
+            let avgSimilarity = totalSimilarity / Double(clusterMessages.count - 1)
+
+            if avgSimilarity > bestAvgSimilarity {
+                bestAvgSimilarity = avgSimilarity
+                bestIdx = item.idx
+                bestMessage = item.message
+            }
+        }
+
+        return (idx: bestIdx, message: bestMessage)
+    }
+
+    /// Calculate pattern score for ranking
+    private func calculatePatternScore(
+        members: [PatternMember],
+        allMessages: [(id: Int64, sessionId: String, repoPath: String, timestamp: Date, embedding: [Double])],
+        clusterIndices: [Int]
+    ) -> PatternScore {
+        let count = members.count
+        let sessionDiversity = Set(members.map { $0.message.sessionId }).count
+        let repoDiversity = Set(members.map { $0.message.repoPath }).count
+
+        // Calculate average internal similarity
+        var totalSimilarity = 0.0
+        var pairCount = 0
+        for i in 0..<clusterIndices.count {
+            for j in (i + 1)..<clusterIndices.count {
+                totalSimilarity += embedder.cosineSimilarity(
+                    allMessages[clusterIndices[i]].embedding,
+                    allMessages[clusterIndices[j]].embedding
+                )
+                pairCount += 1
+            }
+        }
+        let avgSimilarity = pairCount > 0 ? totalSimilarity / Double(pairCount) : 1.0
+
+        // Find most recent message
+        let mostRecent = members.map { $0.message.timestamp }.max() ?? Date.distantPast
+
+        return PatternScore(
+            count: count,
+            sessionDiversity: sessionDiversity,
+            repoDiversity: repoDiversity,
+            avgSimilarity: avgSimilarity,
+            mostRecent: mostRecent
+        )
+    }
+}

--- a/macOS/PromptConduitTests/PatternDetectionServiceTests.swift
+++ b/macOS/PromptConduitTests/PatternDetectionServiceTests.swift
@@ -1,0 +1,328 @@
+import XCTest
+@testable import PromptConduit
+
+final class PatternDetectionServiceTests: XCTestCase {
+
+    var embedder: EmbeddingService!
+
+    override func setUp() {
+        super.setUp()
+        embedder = EmbeddingService()
+    }
+
+    // MARK: - Pattern Score Tests
+
+    func testPatternScoreCompositeCalculation() {
+        let score = PatternScore(
+            count: 5,
+            sessionDiversity: 3,
+            repoDiversity: 2,
+            avgSimilarity: 0.85,
+            mostRecent: Date()
+        )
+
+        // Composite score should be positive and reasonable
+        XCTAssertGreaterThan(score.compositeScore, 0)
+        XCTAssertLessThan(score.compositeScore, 20)  // Sanity check upper bound
+    }
+
+    func testHigherCountIncreasesScore() {
+        let lowCountScore = PatternScore(
+            count: 2,
+            sessionDiversity: 1,
+            repoDiversity: 1,
+            avgSimilarity: 0.8,
+            mostRecent: Date()
+        )
+
+        let highCountScore = PatternScore(
+            count: 10,
+            sessionDiversity: 1,
+            repoDiversity: 1,
+            avgSimilarity: 0.8,
+            mostRecent: Date()
+        )
+
+        XCTAssertGreaterThan(highCountScore.compositeScore, lowCountScore.compositeScore)
+    }
+
+    func testHigherDiversityIncreasesScore() {
+        let lowDiversityScore = PatternScore(
+            count: 5,
+            sessionDiversity: 1,
+            repoDiversity: 1,
+            avgSimilarity: 0.8,
+            mostRecent: Date()
+        )
+
+        let highDiversityScore = PatternScore(
+            count: 5,
+            sessionDiversity: 5,
+            repoDiversity: 3,
+            avgSimilarity: 0.8,
+            mostRecent: Date()
+        )
+
+        XCTAssertGreaterThan(highDiversityScore.compositeScore, lowDiversityScore.compositeScore)
+    }
+
+    func testRecentPatternsScoreHigherThanOld() {
+        let recentScore = PatternScore(
+            count: 5,
+            sessionDiversity: 2,
+            repoDiversity: 1,
+            avgSimilarity: 0.8,
+            mostRecent: Date()
+        )
+
+        let oldScore = PatternScore(
+            count: 5,
+            sessionDiversity: 2,
+            repoDiversity: 1,
+            avgSimilarity: 0.8,
+            mostRecent: Date().addingTimeInterval(-60 * 24 * 3600)  // 60 days ago
+        )
+
+        XCTAssertGreaterThan(recentScore.compositeScore, oldScore.compositeScore)
+    }
+
+    func testHigherSimilarityIncreasesScore() {
+        let lowSimilarityScore = PatternScore(
+            count: 5,
+            sessionDiversity: 2,
+            repoDiversity: 1,
+            avgSimilarity: 0.6,
+            mostRecent: Date()
+        )
+
+        let highSimilarityScore = PatternScore(
+            count: 5,
+            sessionDiversity: 2,
+            repoDiversity: 1,
+            avgSimilarity: 0.95,
+            mostRecent: Date()
+        )
+
+        XCTAssertGreaterThan(highSimilarityScore.compositeScore, lowSimilarityScore.compositeScore)
+    }
+
+    // MARK: - Detected Pattern Tests
+
+    func testDetectedPatternCountMatchesMembers() {
+        // Create a mock pattern with members
+        let mockMessage = IndexedMessage(
+            id: 1,
+            sessionId: "session-1",
+            messageUuid: "uuid-1",
+            messageType: "user",
+            content: "Test content",
+            embedding: [Double](repeating: 0.1, count: 512),
+            repoPath: "/test/repo",
+            timestamp: Date()
+        )
+
+        let members = [
+            PatternMember(id: 1, message: mockMessage, similarityToRepresentative: 1.0),
+            PatternMember(id: 2, message: mockMessage, similarityToRepresentative: 0.9),
+            PatternMember(id: 3, message: mockMessage, similarityToRepresentative: 0.85),
+        ]
+
+        let pattern = DetectedPattern(
+            id: UUID(),
+            representative: mockMessage,
+            members: members,
+            score: PatternScore(count: 3, sessionDiversity: 1, repoDiversity: 1, avgSimilarity: 0.9, mostRecent: Date())
+        )
+
+        XCTAssertEqual(pattern.count, 3)
+        XCTAssertEqual(pattern.count, pattern.members.count)
+    }
+
+    func testDetectedPatternPreview() {
+        let shortContent = "Short content"
+        let shortMessage = IndexedMessage(
+            id: 1,
+            sessionId: "session-1",
+            messageUuid: "uuid-1",
+            messageType: "user",
+            content: shortContent,
+            embedding: [Double](repeating: 0.1, count: 512),
+            repoPath: "/test/repo",
+            timestamp: Date()
+        )
+
+        let shortPattern = DetectedPattern(
+            id: UUID(),
+            representative: shortMessage,
+            members: [],
+            score: PatternScore(count: 1, sessionDiversity: 1, repoDiversity: 1, avgSimilarity: 1.0, mostRecent: Date())
+        )
+
+        XCTAssertEqual(shortPattern.preview, shortContent)
+
+        // Test truncation for long content
+        let longContent = String(repeating: "a", count: 200)
+        let longMessage = IndexedMessage(
+            id: 2,
+            sessionId: "session-2",
+            messageUuid: "uuid-2",
+            messageType: "user",
+            content: longContent,
+            embedding: [Double](repeating: 0.1, count: 512),
+            repoPath: "/test/repo",
+            timestamp: Date()
+        )
+
+        let longPattern = DetectedPattern(
+            id: UUID(),
+            representative: longMessage,
+            members: [],
+            score: PatternScore(count: 1, sessionDiversity: 1, repoDiversity: 1, avgSimilarity: 1.0, mostRecent: Date())
+        )
+
+        XCTAssertEqual(longPattern.preview.count, 103)  // 100 + "..."
+        XCTAssertTrue(longPattern.preview.hasSuffix("..."))
+    }
+
+    func testDetectedPatternSessionCount() {
+        let message1 = IndexedMessage(
+            id: 1,
+            sessionId: "session-1",
+            messageUuid: "uuid-1",
+            messageType: "user",
+            content: "Content 1",
+            embedding: [Double](repeating: 0.1, count: 512),
+            repoPath: "/test/repo",
+            timestamp: Date()
+        )
+
+        let message2 = IndexedMessage(
+            id: 2,
+            sessionId: "session-2",
+            messageUuid: "uuid-2",
+            messageType: "user",
+            content: "Content 2",
+            embedding: [Double](repeating: 0.1, count: 512),
+            repoPath: "/test/repo",
+            timestamp: Date()
+        )
+
+        let message3 = IndexedMessage(
+            id: 3,
+            sessionId: "session-1",  // Same session as message1
+            messageUuid: "uuid-3",
+            messageType: "user",
+            content: "Content 3",
+            embedding: [Double](repeating: 0.1, count: 512),
+            repoPath: "/test/repo",
+            timestamp: Date()
+        )
+
+        let members = [
+            PatternMember(id: 1, message: message1, similarityToRepresentative: 1.0),
+            PatternMember(id: 2, message: message2, similarityToRepresentative: 0.9),
+            PatternMember(id: 3, message: message3, similarityToRepresentative: 0.85),
+        ]
+
+        let pattern = DetectedPattern(
+            id: UUID(),
+            representative: message1,
+            members: members,
+            score: PatternScore(count: 3, sessionDiversity: 2, repoDiversity: 1, avgSimilarity: 0.9, mostRecent: Date())
+        )
+
+        XCTAssertEqual(pattern.sessionCount, 2)  // session-1 and session-2
+    }
+
+    func testDetectedPatternRepoCount() {
+        let message1 = IndexedMessage(
+            id: 1,
+            sessionId: "session-1",
+            messageUuid: "uuid-1",
+            messageType: "user",
+            content: "Content 1",
+            embedding: [Double](repeating: 0.1, count: 512),
+            repoPath: "/test/repo1",
+            timestamp: Date()
+        )
+
+        let message2 = IndexedMessage(
+            id: 2,
+            sessionId: "session-2",
+            messageUuid: "uuid-2",
+            messageType: "user",
+            content: "Content 2",
+            embedding: [Double](repeating: 0.1, count: 512),
+            repoPath: "/test/repo2",
+            timestamp: Date()
+        )
+
+        let members = [
+            PatternMember(id: 1, message: message1, similarityToRepresentative: 1.0),
+            PatternMember(id: 2, message: message2, similarityToRepresentative: 0.9),
+        ]
+
+        let pattern = DetectedPattern(
+            id: UUID(),
+            representative: message1,
+            members: members,
+            score: PatternScore(count: 2, sessionDiversity: 2, repoDiversity: 2, avgSimilarity: 0.9, mostRecent: Date())
+        )
+
+        XCTAssertEqual(pattern.repoCount, 2)
+    }
+
+    // MARK: - Embedding Similarity Tests (Prerequisites for Pattern Detection)
+
+    func testSimilarPromptsHaveHighSimilarity() {
+        guard embedder.isAvailable else {
+            XCTSkip("Embedding service not available")
+            return
+        }
+
+        guard let emb1 = embedder.embed("How do I fix this bug?"),
+              let emb2 = embedder.embed("Help me debug this issue") else {
+            XCTFail("Failed to generate embeddings")
+            return
+        }
+
+        let similarity = embedder.cosineSimilarity(emb1, emb2)
+        XCTAssertGreaterThan(similarity, 0.3, "Similar prompts should have positive similarity")
+    }
+
+    func testDissimilarPromptsHaveLowSimilarity() {
+        guard embedder.isAvailable else {
+            XCTSkip("Embedding service not available")
+            return
+        }
+
+        guard let emb1 = embedder.embed("How do I fix this bug?"),
+              let emb2 = embedder.embed("The weather is sunny today") else {
+            XCTFail("Failed to generate embeddings")
+            return
+        }
+
+        let similarity = embedder.cosineSimilarity(emb1, emb2)
+        XCTAssertLessThan(similarity, 0.5, "Dissimilar prompts should have lower similarity")
+    }
+
+    // MARK: - Pattern Member Tests
+
+    func testPatternMemberIdentifiable() {
+        let message = IndexedMessage(
+            id: 42,
+            sessionId: "session-1",
+            messageUuid: "uuid-1",
+            messageType: "user",
+            content: "Test",
+            embedding: [],
+            repoPath: "/test",
+            timestamp: Date()
+        )
+
+        let member = PatternMember(id: 42, message: message, similarityToRepresentative: 0.95)
+
+        XCTAssertEqual(member.id, 42)
+        XCTAssertEqual(member.similarityToRepresentative, 0.95)
+    }
+}


### PR DESCRIPTION
## Summary

- **Pattern Detection**: Cluster similar user prompts using connected components algorithm with Union-Find
- **Composite Scoring**: Rank patterns by count × session diversity × coherence × recency  
- **New UI Tab**: "Patterns" segment in Sessions Dashboard with expandable pattern cards
- **Representative Selection**: Identifies most central message in each cluster

### Technical Details

**Algorithm:**
- Pairwise cosine similarity comparison (O(n²), acceptable for <10K messages)
- Threshold-based clustering: messages with similarity ≥ 0.75 grouped together
- Union-Find data structure with path compression and rank optimization

**Scoring Formula:**
```
compositeScore = log(count+1)*2 + sessionDiversity*0.5 + avgSimilarity*2 + recencyBonus
```

### New Files
- `PatternDetectionService.swift` - Clustering algorithm and service
- `PatternDetectionServiceTests.swift` - 12 unit tests

### Modified Files  
- `TranscriptIndexDatabase.swift` - Added `getUserMessageEmbeddings()`, `getMessagesByIds()`
- `SessionDashboardView.swift` - Added Patterns tab, PatternRow, patternDetail view

## Test plan

- [ ] Build and launch app
- [ ] Open Sessions Dashboard (Cmd+Shift+D)
- [ ] Switch to "Patterns" tab
- [ ] Verify pattern analysis runs (may show "No Patterns Found" if insufficient data)
- [ ] If patterns exist, verify cards show count, sessions, score
- [ ] Click expand chevron to see cluster members
- [ ] Click pattern to see full detail view
- [ ] Verify similarity percentages are displayed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)