### PR TITLE
feat(app): Generate meaningful session titles from first user prompt

### DIFF
--- a/macOS/PromptConduit.xcodeproj/project.pbxproj
+++ b/macOS/PromptConduit.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		04A1B2C3D4E5F67890AB1234 /* ClaudeSessionDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04A1B2C3D4E5F67890AB1235 /* ClaudeSessionDiscovery.swift */; };
+		04F1G2H3I4J5K67890FG2381 /* SessionTitleCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F1G2H3I4J5K67890FG2380 /* SessionTitleCache.swift */; };
 		04A1B2C3D4E5F67890AB1236 /* SessionDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04A1B2C3D4E5F67890AB1237 /* SessionDashboardView.swift */; };
 		04A1B2C3D4E5F67890AB123A /* ClaudeSessionDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04A1B2C3D4E5F67890AB1239 /* ClaudeSessionDiscoveryTests.swift */; };
 		04B1C2D3E4F5A67890BC2340 /* TranscriptParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04B1C2D3E4F5A67890BC2341 /* TranscriptParser.swift */; };
@@ -110,6 +111,7 @@
 		74B34D1FAC3C18BBD36EFB6F /* TerminalPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPanel.swift; sourceTree = "<group>"; };
 		7B2E2F8E424E5429A197D7E2 /* TerminalOutputMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalOutputMonitorTests.swift; sourceTree = "<group>"; };
 		8AFDA1DAFE542BFD87056608 /* SettingsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsService.swift; sourceTree = "<group>"; };
+		04F1G2H3I4J5K67890FG2380 /* SessionTitleCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTitleCache.swift; sourceTree = "<group>"; };
 		8EE5B376EB05B0E9B6E7AE42 /* PTYSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PTYSessionTests.swift; sourceTree = "<group>"; };
 		93379B0E9848F747EB6489FF /* SessionHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionHistory.swift; sourceTree = "<group>"; };
 		9353377F0E90986D3B597935 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -197,6 +199,7 @@
 				04C1D2E3F4A5B67890CD2351 /* PatternDetectionService.swift */,
 				04D1E2F3G4H5I67890DE2361 /* PatternSkillService.swift */,
 				28E249FE84141C631CAA2DF2 /* ProcessDetectionService.swift */,
+				04F1G2H3I4J5K67890FG2380 /* SessionTitleCache.swift */,
 				8AFDA1DAFE542BFD87056608 /* SettingsService.swift */,
 				AF8BDAA52F7C52621E8DA50B /* SlashCommandsService.swift */,
 				199C59B522537F6E55F7C7FC /* TerminalSessionManager.swift */,
@@ -427,6 +430,7 @@
 				61462559AA7E7FA28451DE41 /* RepositoryTemplate.swift in Sources */,
 				4626CA9A8C2A3CEBE88B7F99 /* SessionHistory.swift in Sources */,
 				EC1BEAFC018797D42BD93309 /* SessionLauncherView.swift in Sources */,
+				04F1G2H3I4J5K67890FG2381 /* SessionTitleCache.swift in Sources */,
 				DB6E622451AD0A224C2DBAC2 /* SettingsService.swift in Sources */,
 				3871A6B448C1D5DCC7CD8B1D /* SettingsView.swift in Sources */,
 				D77341296B4C490111B91889 /* SlashCommandsService.swift in Sources */,

--- a/macOS/PromptConduit/Services/SessionTitleCache.swift
+++ b/macOS/PromptConduit/Services/SessionTitleCache.swift
@@ -1,0 +1,194 @@
+import Foundation
+import SQLite3
+
+/// Caches generated session titles to avoid re-parsing transcripts
+class SessionTitleCache {
+
+    static let shared = SessionTitleCache()
+
+    private var db: OpaquePointer?
+    private let dbPath: String
+
+    private init() {
+        // Store in ~/.config/promptconduit/
+        let configDir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config/promptconduit")
+
+        // Create directory if needed
+        try? FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+
+        dbPath = configDir.appendingPathComponent("session_titles.db").path
+        openDatabase()
+        createTable()
+    }
+
+    deinit {
+        sqlite3_close(db)
+    }
+
+    // MARK: - Database Setup
+
+    private func openDatabase() {
+        if sqlite3_open(dbPath, &db) != SQLITE_OK {
+            print("SessionTitleCache: Failed to open database at \(dbPath)")
+        }
+    }
+
+    private func createTable() {
+        let sql = """
+            CREATE TABLE IF NOT EXISTS session_titles (
+                session_id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                source TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            );
+            """
+
+        var errMsg: UnsafeMutablePointer<CChar>?
+        if sqlite3_exec(db, sql, nil, nil, &errMsg) != SQLITE_OK {
+            if let errMsg = errMsg {
+                print("SessionTitleCache: Failed to create table: \(String(cString: errMsg))")
+                sqlite3_free(errMsg)
+            }
+        }
+    }
+
+    // MARK: - Public API
+
+    /// Get cached title for a session
+    func getTitle(sessionId: String) -> String? {
+        let sql = "SELECT title FROM session_titles WHERE session_id = ?;"
+
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            return nil
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        sqlite3_bind_text(stmt, 1, sessionId, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+
+        if sqlite3_step(stmt) == SQLITE_ROW {
+            if let cString = sqlite3_column_text(stmt, 0) {
+                return String(cString: cString)
+            }
+        }
+
+        return nil
+    }
+
+    /// Store a generated title for a session
+    func setTitle(sessionId: String, title: String, source: String = "first_prompt") {
+        let sql = """
+            INSERT OR REPLACE INTO session_titles (session_id, title, source, created_at)
+            VALUES (?, ?, ?, ?);
+            """
+
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            return
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+        let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+        sqlite3_bind_text(stmt, 1, sessionId, -1, transient)
+        sqlite3_bind_text(stmt, 2, title, -1, transient)
+        sqlite3_bind_text(stmt, 3, source, -1, transient)
+        sqlite3_bind_text(stmt, 4, timestamp, -1, transient)
+
+        if sqlite3_step(stmt) != SQLITE_DONE {
+            print("SessionTitleCache: Failed to insert title for \(sessionId)")
+        }
+    }
+
+    /// Clear all cached titles (for debugging)
+    func clearCache() {
+        let sql = "DELETE FROM session_titles;"
+        var errMsg: UnsafeMutablePointer<CChar>?
+        if sqlite3_exec(db, sql, nil, nil, &errMsg) != SQLITE_OK {
+            if let errMsg = errMsg {
+                print("SessionTitleCache: Failed to clear cache: \(String(cString: errMsg))")
+                sqlite3_free(errMsg)
+            }
+        }
+    }
+
+    /// Get total number of cached titles
+    var count: Int {
+        let sql = "SELECT COUNT(*) FROM session_titles;"
+
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            return 0
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        if sqlite3_step(stmt) == SQLITE_ROW {
+            return Int(sqlite3_column_int(stmt, 0))
+        }
+
+        return 0
+    }
+}
+
+// MARK: - Title Generation Utilities
+
+extension SessionTitleCache {
+
+    /// Generates a clean, display-friendly title from a user prompt
+    /// - Parameter prompt: The raw user prompt text
+    /// - Returns: A cleaned title suitable for display (max 60 chars)
+    static func generateTitle(from prompt: String) -> String {
+        var text = prompt
+
+        // Take first line only
+        if let firstLineEnd = text.firstIndex(of: "\n") {
+            text = String(text[..<firstLineEnd])
+        }
+
+        // Trim whitespace
+        text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Strip common conversational prefixes (case-insensitive)
+        let prefixes = [
+            "help me ", "can you ", "could you ", "please ", "i need to ",
+            "i want to ", "i'd like to ", "let's ", "let me ", "we need to ",
+            "hi, ", "hey, ", "hello, ", "hi ", "hey ", "hello "
+        ]
+
+        let lowercased = text.lowercased()
+        for prefix in prefixes {
+            if lowercased.hasPrefix(prefix) {
+                text = String(text.dropFirst(prefix.count))
+                // Capitalize first letter after stripping
+                if let first = text.first {
+                    text = first.uppercased() + text.dropFirst()
+                }
+                break
+            }
+        }
+
+        // Trim again after stripping prefix
+        text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // If still empty, return a default
+        guard !text.isEmpty else {
+            return "Untitled Session"
+        }
+
+        // If short enough, return as-is
+        if text.count <= 60 {
+            return text
+        }
+
+        // Truncate at word boundary
+        let truncated = String(text.prefix(57))
+        if let lastSpace = truncated.lastIndex(of: " ") {
+            return String(truncated[..<lastSpace]) + "..."
+        }
+
+        // No space found, just truncate
+        return truncated + "..."
+    }
+}


### PR DESCRIPTION
## Summary
- Sessions without Claude-generated summaries now show first user prompt as title
- Replaces unhelpful UUID prefixes like "06e7a9eb..." with meaningful descriptions
- Titles are cached in SQLite to avoid re-parsing transcripts on every load

## Changes
- Add `SessionTitleCache` service with SQLite-backed persistent storage
- Modify `ClaudeSessionDiscovery` to extract and generate titles from first prompt
- Clean prompts for display (max 60 chars, word boundary truncation)
- Strip common conversational prefixes ("Help me", "Can you", etc.)

## Title Resolution Priority
1. `leafTitle` from summary message (Claude-generated, best quality)
2. `summary` field from summary message
3. Cached generated title from SessionTitleCache
4. Generated from first user prompt (new)
5. UUID prefix fallback (only for empty/unreadable files)

## Test plan
- [ ] Build and launch app
- [ ] Open Sessions Dashboard (Cmd+Shift+D)
- [ ] Verify sessions that previously showed UUIDs now show first prompt text
- [ ] Verify sessions with summaries still show Claude-generated titles
- [ ] Close and reopen dashboard - titles should load instantly from cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)