### PR TITLE
fix(app): Refactor session management to single source of truth architecture

### DIFF
--- a/macOS/PromptConduit/Features/Terminal/MonitoredTerminalView.swift
+++ b/macOS/PromptConduit/Features/Terminal/MonitoredTerminalView.swift
@@ -45,9 +45,10 @@ class MonitoredTerminalView: LocalProcessTerminalView {
     /// Patterns that indicate Claude is ready for input
     /// Claude Code shows "Try" suggestions when ready for input
     private let readyPatterns = [
-        "> Try \"",     // Claude Code suggestion prompt (main indicator it's ready)
+        "Try \"",      // Claude Code suggestion prompt (main indicator it's ready)
+        "❯ Try",       // With Unicode prompt character
+        "> Try",       // With ASCII prompt character
         "❯",           // Claude's primary prompt (terminal mode)
-        "❯ ",          // Prompt with space
     ]
 
     // MARK: - Selection State
@@ -551,15 +552,14 @@ class MonitoredTerminalView: LocalProcessTerminalView {
         // Debug: check the last 200 chars of clean output
         let tail = String(cleanOutput.suffix(200))
         if tail.contains("Try") {
-            print("[MonitoredTerminal] FOUND 'Try' in tail: \(tail.prefix(100))")
+            terminalLog("[READY] FOUND 'Try' in output tail")
         }
 
         for pattern in readyPatterns {
             if cleanOutput.contains(pattern) {
-                print("[MonitoredTerminal] Claude ready! Detected pattern: '\(pattern)'")
+                terminalLog("[READY] Claude ready! Detected pattern: '\(pattern)'")
                 isClaudeReady = true
                 DispatchQueue.main.async { [weak self] in
-                    print("[MonitoredTerminal] Calling onClaudeReady callback")
                     self?.onClaudeReady?()
                 }
                 break


### PR DESCRIPTION
## Summary

- Fix session mirroring bug caused by directory name fallback matching sessions incorrectly
- Fix callback overwrite bug where MultiTerminalGridView was overwriting TerminalSessionManager's hook callbacks
- Refactor to unidirectional data flow architecture following principle engineer best practices

## Changes

### Architecture Refactor
- **TerminalSessionManager** is now the single source of truth for all session state
- Added `pendingPrompt`, `isReadyForPrompt`, `promptSent` to `TerminalSessionInfo`
- Added `@Published sessionsReadyForPrompt` for views to observe
- Views observe state changes via Combine instead of handling events directly

### Bug Fixes
- Removed unsafe directory name fallback that caused sessions to be matched incorrectly
- Use prefix matching for hook events (cwd may be subdirectory of repo path)
- Fixed callback overwrite issue - now both TerminalSessionManager and views can react to events

### Data Flow
```
HookNotificationService (receives CLI events)
        │
        ▼
TerminalSessionManager (processes events, updates state)
        │
        ▼ @Published sessionsReadyForPrompt
MultiTerminalGridView (observes state, sends prompts)
```

## Test plan
- [ ] Create a new session group with multiple repos
- [ ] Verify prompt is sent to all sessions
- [ ] Verify sessions don't get mirrored/mixed up
- [ ] Verify waiting/running status updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)