### PR TITLE
docs: screenshot placeholder in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A native macOS menu bar app that tracks your Claude Code sessions and manages your skills library.
 
+![PromptConduit sessions dashboard](docs/screenshot-sessions.png)
+
 ## What It Does
 
 PromptConduit sits in your menu bar and watches your Claude Code sessions in real-time. It gives you visibility into your coding activity and a central place to manage reusable slash commands.


### PR DESCRIPTION
## Summary

Adds an image reference to the README at \`docs/screenshot-sessions.png\`. The screenshot itself needs to be captured and committed — see note below.

## To complete this PR

1. Launch the app
2. Open the Sessions Dashboard (Cmd+Shift+D)
3. Capture the window: \`screencapture -w docs/screenshot-sessions.png\`
4. \`git add docs/screenshot-sessions.png && git commit -m "docs: add sessions dashboard screenshot" && git push\`

The README will then render the screenshot directly below the title.

## Checklist
- [ ] Screenshot captured and committed to \`docs/screenshot-sessions.png\`
- [x] No breaking changes
- [x] No platform internals